### PR TITLE
Remove bottle unneeded

### DIFF
--- a/Formula/helix.rb
+++ b/Formula/helix.rb
@@ -5,7 +5,6 @@ class Helix < Formula
   sha256 "4789acfa22c996ece3d4069422c86177b062f099d7fccaf8a253c9ad9553759a"
   license "MPL-2.0"
 
-  bottle :unneeded
   def install
     libexec.install Dir["*"]
     (bin/"hx").write_env_script(libexec/"hx", :HELIX_RUNTIME => libexec/"runtime")


### PR DESCRIPTION
According to homebrew: "Calling bottle :unneeded is deprecated! There is no replacement."