### PR TITLE
Add Linux support

### DIFF
--- a/Formula/helix.rb
+++ b/Formula/helix.rb
@@ -1,9 +1,22 @@
 class Helix < Formula
+  version "22.03"
   desc "Post-modern modal text editor"
   homepage "https://helix-editor.com"
-  url "https://github.com/helix-editor/helix/releases/download/22.03/helix-22.03-x86_64-macos.tar.xz"
-  sha256 "4624be398aff68af39c40ef401ec95a2d8722ae724328c1204afb663ffde72fb"
   license "MPL-2.0"
+
+  on_macos do
+    # We don't need a Hardware::CPU.intel? check here. The x86_64 binary
+    # will also work for ARM64.
+    url "https://github.com/helix-editor/helix/releases/download/#{version}/helix-#{version}-x86_64-macos.tar.xz"
+    sha256 "4624be398aff68af39c40ef401ec95a2d8722ae724328c1204afb663ffde72fb"
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/helix-editor/helix/releases/download/#{version}/helix-#{version}-x86_64-linux.tar.xz"
+      sha256 "844ec88c81e2e4ca6153499a8b371cfbd3602f32492326b91bf2547d515f528f"
+    end
+  end
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
I've added support for Linuxbrew. 

I noticed that you initially created a [separate repo](https://github.com/helix-editor/homebrew-helix-linuxbrew) for this but this is not required. We can define Linux specific behavior in the same formula file. Since the content of the tarballs is the same therefore the only change was the URL structure and SHA256.

I tested on Ubuntu and it works as expected.

Additionally, I also tested on my M1 MacBook and the formula works there too. With that said, native ARM64 binaries would be preferred and will also probably be faster.