### PR TITLE
Add shell completion (again)

### DIFF
--- a/Formula/helix.rb
+++ b/Formula/helix.rb
@@ -26,6 +26,10 @@ class Helix < Formula
   end
 
   def install
+    bash_completion.install "contrib/completion/hx.bash" => "hx"
+    fish_completion.install "contrib/completion/hx.fish"
+    zsh_completion.install "contrib/completion/hx.zsh" => "_hx"
+
     if build.head?
       system "cargo", "install", *std_cargo_args(path: "helix-term")
       libexec.install "runtime"


### PR DESCRIPTION
as `Dir["*"]` is used to install stable, this specific step has to be done before

fixes #8 